### PR TITLE
fix: not working on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function (port, opts) {
 
 	return new Promise(function (resolve) {
 		netstats(port).then(function (stats) {
-			process(stats).then(function (ps) {
+			processNetStats(stats).then(function (ps) {
 				resolve(ps);
 			});
 		}).catch(function () {
@@ -29,7 +29,7 @@ module.exports = function (port, opts) {
 	});
 };
 
-function process(arr) {
+function processNetStats(arr) {
 	var pidindex = 1;
 	var items = arr.slice(1);
 


### PR DESCRIPTION
The function 'process' overrode Node's built-in `process` object resulting in `process.platform` being `undefined`, hence not working on Windows. This fixes it.

Fixes #2