### PR TITLE
 fix: local scoped pids, refactor 

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function (port, opts) {
 
 	return new Promise(function (resolve) {
 		netstats(port).then(function (stats) {
-			process(stats).then(function (ps) {
+			processNetStats(stats).then(function (ps) {
 				resolve(ps);
 			});
 		}).catch(function () {
@@ -29,7 +29,7 @@ module.exports = function (port, opts) {
 	});
 };
 
-function process(arr) {
+function processNetStats(arr) {
 	var pidindex = 1;
 	var items = arr.slice(1);
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "pids"
   ],
   "dependencies": {
-    "each-async": "^1.1.1",
     "native-promise-only": "^0.8.1",
     "netstats": "0.0.5",
     "selective-whitespace": "^1.0.0"


### PR DESCRIPTION
`pids` were globally defined, resulting in previous `pids` being returned on subsequent requests.

Refactored code to use `Promise.all` instead of `each-async`

(includes #3)

Fixes #1